### PR TITLE
fix: remove need for gh token for linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,6 @@ jobs:
       - name: run tests
         run: |
           pytest -vvs tests
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ensure cli runs
         run: |

--- a/conda_forge_feedstock_ops/lint.py
+++ b/conda_forge_feedstock_ops/lint.py
@@ -21,10 +21,6 @@ logger = logging.getLogger(__name__)
 def lint(feedstock_dir, use_container=None):
     """Lint all of the recipes in a feedstock.
 
-    **WARNING: This function will inject the GH_TOKEN env var into
-    the container in order to run conda-forge-specific linting.
-    Make sure that token is read-only.**
-
     Parameters
     ----------
     feedstock_dir : str
@@ -74,7 +70,6 @@ def _lint_containerized(feedstock_dir):
             mount_readonly=True,
             mount_dir=tmpdir,
             json_loads=loads,
-            extra_container_args=["-e", "GH_TOKEN"],
         )
 
         # When tempfile removes tempdir, it tries to reset permissions on subdirs.

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ platforms:
 dependencies:
   - click
   - conda-build >=3.27
-  - conda-smithy
+  - conda-smithy >=3.40
   - python-rapidjson
   - pyyaml
   - rattler-build-conda-compat >=0.0.2,<2.0.0a0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,10 +42,6 @@ skipif_no_containers = pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
 
-skipif_no_github_token = pytest.mark.skipif(
-    "GH_TOKEN" not in os.environ, reason="no GH_TOKEN in environment"
-)
-
 
 @pytest.fixture(autouse=True, scope="session")
 def set_cf_feedstock_ops_container_tag_to_test():

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,11 +1,10 @@
 import os
 
-from conftest import skipif_no_containers, skipif_no_github_token
+from conftest import skipif_no_containers
 
 from conda_forge_feedstock_ops.lint import lint
 
 
-@skipif_no_github_token
 def test_lint_local():
     feedstock_dir = os.path.join(os.path.dirname(__file__), "data")
     lints, hints = lint(


### PR DESCRIPTION
This PR removes the need for a token for linting.

xref: https://github.com/conda-forge/conda-smithy/pull/2063