### PR TITLE
test: ensure correct permissions on created files after rerender

### DIFF
--- a/conda_forge_feedstock_ops/rerender.py
+++ b/conda_forge_feedstock_ops/rerender.py
@@ -124,7 +124,7 @@ def rerender_containerized(feedstock_dir, timeout=None):
                 check=True,
                 cwd=feedstock_dir,
             )
-            logger.warning("rerender patch:\n%s", data["patch"])  # FIXME
+            print("rerender patch:\n%s", data["patch"], flush=True)  # FIXME
             reset_permissions_with_user_execute(feedstock_dir, data["permissions"])
             subprocess.run(
                 ["git", "add", "."],

--- a/conda_forge_feedstock_ops/rerender.py
+++ b/conda_forge_feedstock_ops/rerender.py
@@ -124,6 +124,7 @@ def rerender_containerized(feedstock_dir, timeout=None):
                 check=True,
                 cwd=feedstock_dir,
             )
+            logger.warning("rerender patch:\n%s", data["patch"])  # FIXME
             reset_permissions_with_user_execute(feedstock_dir, data["permissions"])
             subprocess.run(
                 ["git", "add", "."],

--- a/conda_forge_feedstock_ops/rerender.py
+++ b/conda_forge_feedstock_ops/rerender.py
@@ -124,7 +124,6 @@ def rerender_containerized(feedstock_dir, timeout=None):
                 check=True,
                 cwd=feedstock_dir,
             )
-            print("rerender patch:\n%s", data["patch"], flush=True)  # FIXME
             reset_permissions_with_user_execute(feedstock_dir, data["permissions"])
             subprocess.run(
                 ["git", "add", "."],

--- a/tests/test_rerender.py
+++ b/tests/test_rerender.py
@@ -303,10 +303,15 @@ def test_rerender_containerized_permissions(use_containers):
                 print(
                     f"\n\ninput permissions for build-locally.py: {orig_perms_bl:#o}\n\n"
                 )
+                orig_perms_bs = os.stat(".scripts/build_steps.sh").st_mode
+                print(
+                    f"\n\ninput permissions for .scripts/build_steps.sh: {orig_perms_bs:#o}\n\n"
+                )
                 local_rerend_exec = get_user_execute_permissions(".")
 
                 cmds = [
-                    ["chmod", "655", "build-locally.py"],
+                    ["chmod", "600", "build-locally.py"],
+                    ["git", "rm", "-f", ".scripts/build_steps.sh"],
                     ["git", "add", "build-locally.py"],
                     ["git", "config", "user.email", "conda@conda.conda"],
                     ["git", "config", "user.name", "conda c. conda"],
@@ -326,6 +331,10 @@ def test_rerender_containerized_permissions(use_containers):
             with pushd("conda-forge-feedstock-check-solvable-feedstock"):
                 perms_bl = os.stat("build-locally.py").st_mode
                 print(f"\n\nfinal permissions for build-locally.py: {perms_bl:#o}\n\n")
+                perms_bs = os.stat(".scripts/build_steps.sh").st_mode
+                print(
+                    f"\n\nfinal permissions for .scripts/build_steps.sh: {perms_bs:#o}\n\n"
+                )
                 cont_rerend_exec = get_user_execute_permissions(".")
 
             assert orig_exec == local_rerend_exec

--- a/tests/test_rerender.py
+++ b/tests/test_rerender.py
@@ -281,6 +281,10 @@ def test_rerender_containerized_permissions(use_containers):
                 print(
                     f"\n\ncloned permissions for build-locally.py: {orig_perms_bl:#o}\n\n"
                 )
+                orig_perms_bs = os.stat(".scripts/build_steps.sh").st_mode
+                print(
+                    f"\n\ncloned permissions for .scripts/build_steps.sh: {orig_perms_bs:#o}\n\n"
+                )
                 orig_exec = get_user_execute_permissions(".")
 
             local_msg = rerender_local(


### PR DESCRIPTION
This PR adds a test for issue #25.