### PR TITLE
Add proxy mode to `run_container_operation`

### DIFF
--- a/conda_forge_feedstock_ops/container_utils.py
+++ b/conda_forge_feedstock_ops/container_utils.py
@@ -20,6 +20,17 @@ Whether to use a proxy that is locally configured for all requests inside the co
 Set the environment variable `CF_FEEDSTOCK_OPS_CONTAINER_PROXY_MODE` to 'true' to enable this feature.
 """
 
+PROXY_IN_CONTAINER = os.environ.get(
+    "CF_FEEDSTOCK_OPS_PROXY_IN_CONTAINER", "http://host.docker.internal:8080"
+)
+"""
+The hostname of the proxy to use in the container.
+The default value of 'http://host.docker.internal:8080' is the default value for Docker Desktop on Windows and macOS.
+It also works for OrbStack.
+
+For podman, use http://host.containers.internal:8080.
+For GitHub Actions, use http://172.17.0.1:8080, see https://stackoverflow.com/a/65505308
+"""
 
 def get_default_container_name():
     """Get the default container name for feedstock ops.
@@ -111,9 +122,9 @@ def _get_proxy_mode_container_args():
     assert os.environ["SSL_CERT_FILE"] == os.environ["REQUESTS_CA_BUNDLE"]
     return [
         "-e",
-        f"http_proxy={os.environ['http_proxy']}",
+        f"http_proxy={PROXY_IN_CONTAINER}",
         "-e",
-        f"https_proxy={os.environ['https_proxy']}",
+        f"https_proxy={PROXY_IN_CONTAINER}",
         "-e",
         f"no_proxy={os.environ.get('no_proxy', '')}",
         "-e",

--- a/conda_forge_feedstock_ops/container_utils.py
+++ b/conda_forge_feedstock_ops/container_utils.py
@@ -32,6 +32,7 @@ For podman, use http://host.containers.internal:8080.
 For GitHub Actions, use http://172.17.0.1:8080, see https://stackoverflow.com/a/65505308
 """
 
+
 def get_default_container_name():
     """Get the default container name for feedstock ops.
 


### PR DESCRIPTION
For https://github.com/regro/cf-scripts/issues/261, we would like to use an http proxy (we currently use mitm proxy) to mock requests (WIP code in https://github.com/ytausch/cf-scripts/pull/2).
For this, we need to pass the proxy through to the docker containers as well.

CC @ytausch