### PR TITLE
feat: use pydantic settings object to manage settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ from conda_forge_feedstock_ops.rerender import rerender
 commit_msg = rerender(path_to_feedstock)
 ```
 
+## Settings
+
+You can customize the behavior of the package by setting environment variables as described in [settings.py](conda_forge_feedstock_ops/settings.py).
+
 ## Container Setup
 
 This package works by running commands inside of a container on-the-fly in order to

--- a/conda_forge_feedstock_ops/container_utils.py
+++ b/conda_forge_feedstock_ops/container_utils.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONTAINER_TMPFS_SIZE_MB = 6000
 
 
+def get_default_container_name():
+    return FeedstockOpsSettings().container_full_name
+
+
 class ContainerRuntimeError(RuntimeError):
     """An error raised when running a container fails."""
 
@@ -154,7 +158,7 @@ def run_container_operation(
         *mnt_args,
         *_get_proxy_mode_container_args(),
         *extra_container_args,
-        FeedstockOpsSettings().container_full_name,
+        get_default_container_name(),
         *args,
     ]
     res = subprocess.run(

--- a/conda_forge_feedstock_ops/container_utils.py
+++ b/conda_forge_feedstock_ops/container_utils.py
@@ -6,49 +6,11 @@ import subprocess
 from collections.abc import Iterable
 from typing import Callable, Optional
 
-from ._version import __version__
+from conda_forge_feedstock_ops.settings import FeedstockOpsSettings
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONTAINER_TMPFS_SIZE_MB = 6000
-
-CONTAINER_PROXY_MODE = os.environ.get(
-    "CF_FEEDSTOCK_OPS_CONTAINER_PROXY_MODE", "false"
-).lower() in ("yes", "true", "t", "1")
-"""
-Whether to use a proxy that is locally configured for all requests inside the container.
-Set the environment variable `CF_FEEDSTOCK_OPS_CONTAINER_PROXY_MODE` to 'true' to enable this feature.
-"""
-
-PROXY_IN_CONTAINER = os.environ.get(
-    "CF_FEEDSTOCK_OPS_PROXY_IN_CONTAINER", "http://host.docker.internal:8080"
-)
-"""
-The hostname of the proxy to use in the container.
-The default value of 'http://host.docker.internal:8080' is the default value for Docker Desktop on Windows and macOS.
-It also works for OrbStack.
-
-For podman, use http://host.containers.internal:8080.
-For GitHub Actions, use http://172.17.0.1:8080, see https://stackoverflow.com/a/65505308
-"""
-
-
-def get_default_container_name():
-    """Get the default container name for feedstock ops.
-
-    The image is stored at `condaforge/conda-forge-feedstock-ops`.
-
-    If the environment variable `CF_FEEDSTOCK_OPS_CONTAINER_NAME` is set, then that name is used.
-
-    If the environment variable `CF_FEEDSTOCK_OPS_CONTAINER_TAG` is set, then that tag is pulled.
-    Otherwise, we pull the tag `__version__`.
-    """
-    cname = (
-        f"{os.environ.get('CF_FEEDSTOCK_OPS_CONTAINER_NAME', 'condaforge/conda-forge-feedstock-ops')}"
-        + f":{os.environ.get('CF_FEEDSTOCK_OPS_CONTAINER_TAG', __version__)}"
-    )
-
-    return cname
 
 
 class ContainerRuntimeError(RuntimeError):
@@ -118,14 +80,16 @@ def get_default_log_level_args(logger):
 
 
 def _get_proxy_mode_container_args():
-    if not CONTAINER_PROXY_MODE:
+    settings = FeedstockOpsSettings()
+    if not settings.container_proxy_mode:
         return []
+
     assert os.environ["SSL_CERT_FILE"] == os.environ["REQUESTS_CA_BUNDLE"]
     return [
         "-e",
-        f"http_proxy={PROXY_IN_CONTAINER}",
+        f"http_proxy={settings.proxy_in_container}",
         "-e",
-        f"https_proxy={PROXY_IN_CONTAINER}",
+        f"https_proxy={settings.proxy_in_container}",
         "-e",
         f"no_proxy={os.environ.get('no_proxy', '')}",
         "-e",
@@ -190,7 +154,7 @@ def run_container_operation(
         *mnt_args,
         *_get_proxy_mode_container_args(),
         *extra_container_args,
-        get_default_container_name(),
+        FeedstockOpsSettings().container_full_name,
         *args,
     ]
     res = subprocess.run(
@@ -290,9 +254,7 @@ def should_use_container(use_container: Optional[bool] = None):
     bool
         Whether to use a container.
     """
-    in_container = (
-        os.environ.get("CF_FEEDSTOCK_OPS_IN_CONTAINER", "false").lower() == "true"
-    )
+    in_container = FeedstockOpsSettings().in_container
     if use_container is None:
         use_container = not in_container
 

--- a/conda_forge_feedstock_ops/settings.py
+++ b/conda_forge_feedstock_ops/settings.py
@@ -1,0 +1,83 @@
+import sys
+from typing import Annotated, Self
+
+from pydantic import AfterValidator, AnyHttpUrl, Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from ._version import __version__
+
+# https://github.com/pydantic/pydantic/issues/7186#issuecomment-1691594032
+HttpProxyUrl = Annotated[AnyHttpUrl, AfterValidator(lambda x: str(x).rstrip("/"))]
+
+
+def get_docker_host_hostname() -> str:
+    """
+    Get the default value for the `proxy_in_container` setting.
+    https://stackoverflow.com/a/65505308
+    """
+    if sys.platform == "linux":
+        return "http://172.17.0.1:8080"
+    return "http://host.docker.internal:8080"
+
+
+class FeedstockOpsSettings(BaseSettings):
+    """
+    The global settings object read from environment variables.
+
+    To change a setting, set the environment variable `CF_FEEDSTOCK_OPS_<SETTING_NAME>`.
+    Keys are case-insensitive. For example, to set the `container_name` setting, set the
+    environment variable `CF_FEEDSTOCK_OPS_CONTAINER_NAME`.
+
+    Developer note: Please note that consumers of this library might want to change some settings in between function
+    invocations. Therefore, don't store the settings object in a global variable.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="CF_FEEDSTOCK_OPS_")
+
+    container_name: str = "condaforge/conda-forge-feedstock-ops"
+    """
+    The Docker image name to use for the container.
+    """
+
+    container_tag: str = __version__
+    """
+    The Docker image tag to use for the container. Defaults to the current version of this package.
+    """
+
+    in_container: bool = False
+    """
+    Whether the code is already running inside a container.
+    """
+
+    @property
+    def container_full_name(self) -> str:
+        """
+        The full name of the Docker image to use for the container in the format `container_name:container_tag`.
+        """
+        return f"{self.container_name}:{self.container_tag}"
+
+    container_proxy_mode: bool = False
+    """
+    Whether to use a proxy that is locally configured for all requests inside the container.
+    """
+
+    proxy_in_container: HttpProxyUrl = Field(default_factory=get_docker_host_hostname)
+    """
+    The hostname of the proxy to use in the container.
+    The default value should reference the Docker host's hostname and works for
+    - Docker Desktop on Windows and macOS
+    - OrbStack
+
+    For podman, set this manually to http://host.containers.internal:8080.
+    """
+
+    @model_validator(mode="after")
+    def check_forgotten_container_proxy_mode(self) -> Self:
+        if (
+            "proxy_in_container" in self.model_fields_set
+            and not self.container_proxy_mode
+        ):
+            raise ValueError(
+                "The `proxy_in_container` setting requires `container_proxy_mode` to be enabled."
+            )
+        return self

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - click
   - conda-build >=3.27
   - conda-smithy >=3.40
+  - pydantic-settings >=2.8.1,<3.0.0
   - python-rapidjson
   - pyyaml
   - rattler-build-conda-compat >=0.0.2,<2.0.0a0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,3 +99,10 @@ def use_containers():
         os.environ.pop("CF_FEEDSTOCK_OPS_IN_CONTAINER", None)
     else:
         os.environ["CF_FEEDSTOCK_OPS_IN_CONTAINER"] = old_in_container
+
+
+@pytest.fixture
+def temporary_env_variables():
+    old_env = os.environ.copy()
+    yield
+    os.environ = old_env

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,63 @@
+import os
+from unittest import mock
+
+import pytest
+from pydantic import ValidationError
+
+from conda_forge_feedstock_ops._version import __version__
+from conda_forge_feedstock_ops.settings import FeedstockOpsSettings
+
+
+class TestFeedstockOpsSettings:
+    def test_example_parsing(self, temporary_env_variables):
+        os.environ["CF_FEEDSTOCK_OPS_CONTAINER_NAME"] = "test-container"
+        os.environ["CF_FEEDSTOCK_OPS_CONTAINER_TAG"] = "test-tag"
+        os.environ["CF_FEEDSTOCK_OPS_IN_CONTAINER"] = "true"
+        os.environ["CF_FEEDSTOCK_OPS_CONTAINER_PROXY_MODE"] = "true"
+        os.environ["CF_FEEDSTOCK_OPS_PROXY_IN_CONTAINER"] = "http://proxy:8000"
+
+        settings = FeedstockOpsSettings()
+
+        assert settings.container_name == "test-container"
+        assert settings.container_tag == "test-tag"
+        assert settings.in_container is True
+        assert settings.container_proxy_mode is True
+        assert str(settings.proxy_in_container) == "http://proxy:8000"
+
+        assert settings.container_full_name == "test-container:test-tag"
+
+    @pytest.mark.parametrize(
+        "platform, expected_proxy",
+        [
+            ["linux", "http://172.17.0.1:8080"],
+            ["darwin", "http://host.docker.internal:8080"],
+            ["win32", "http://host.docker.internal:8080"],
+        ],
+    )
+    def test_default_values(
+        self, platform: str, expected_proxy: str, temporary_env_variables
+    ):
+        os.environ.clear()
+
+        with mock.patch("conda_forge_feedstock_ops.settings.sys.platform", platform):
+            settings = FeedstockOpsSettings()
+
+        assert settings.container_name == "condaforge/conda-forge-feedstock-ops"
+        assert settings.container_tag == __version__
+        assert settings.in_container is False
+        assert settings.container_proxy_mode is False
+        assert str(settings.proxy_in_container) == expected_proxy
+        assert (
+            settings.container_full_name
+            == f"{settings.container_name}:{settings.container_tag}"
+        )
+
+    def test_check_forgotten_container_proxy_mode(self, temporary_env_variables):
+        os.environ.clear()
+
+        os.environ["CF_FEEDSTOCK_OPS_PROXY_IN_CONTAINER"] = "http://proxy:8000"
+
+        with pytest.raises(
+            ValidationError, match="requires `container_proxy_mode` to be enabled"
+        ):
+            FeedstockOpsSettings()


### PR DESCRIPTION
While working on the cf-scripts integration tests, I stumbled upon the issue that I need to modify some settings controlled via environment variables between function invocations. Currently, this is not possible because there are environment variables read at import time.

This PR introduces a `FeedstockOpsSettings` object based on [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) which centralizes all settings controlled via environment variables. Since the object is not cached, it is now possible to change settings between function invocations by modifying the environment variables.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Blocks https://github.com/regro/cf-scripts/pull/3417

TODO after merge:
- add `pydantic-settings` dependency to https://github.com/conda-forge/conda-forge-feedstock-ops-feedstock

Cc @pavelzw