### PR TITLE
fix: do not reassign os.environ

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,4 +105,5 @@ def use_containers():
 def temporary_env_variables():
     old_env = os.environ.copy()
     yield
-    os.environ = old_env
+    os.environ.clear()
+    os.environ.update(old_env)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
As pointed out here:  https://github.com/regro/cf-scripts/pull/3932#discussion_r2010246493


<!--
Please add any other relevant info below:
-->
