### PR TITLE
BREAKING CHANGE: make run_container_operation accept multiple mounts

### DIFF
--- a/conda_forge_feedstock_ops/__init__.py
+++ b/conda_forge_feedstock_ops/__init__.py
@@ -1,4 +1,12 @@
+from pathlib import PurePosixPath
+
 from ._version import __version__  # noqa
+
+CF_FEEDSTOCK_OPS_DIR = PurePosixPath("/cf_feedstock_ops_dir")
+"""
+This is a special directory inside the container which is marked as safe git directory.
+You can mount your feedstock directory under this directory.
+"""
 
 
 def setup_logging(level: str = "INFO") -> None:

--- a/conda_forge_feedstock_ops/lint.py
+++ b/conda_forge_feedstock_ops/lint.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import conda_smithy.lint_recipe
 
 from conda_forge_feedstock_ops.container_utils import (
+    Mount,
     get_default_log_level_args,
     run_container_operation,
     should_use_container,
@@ -70,9 +71,8 @@ def _lint_containerized(feedstock_dir):
         )
 
         data = run_container_operation(
-            args,
-            mount_readonly=True,
-            mount_dir=tmpdir,
+            args=args,
+            mounts=[Mount.to_cf_feedstock_ops_dir(tmpdir, read_only=True)],
             json_loads=loads,
         )
 

--- a/conda_forge_feedstock_ops/lint.py
+++ b/conda_forge_feedstock_ops/lint.py
@@ -53,9 +53,10 @@ def _lint_containerized(feedstock_dir):
         "lint",
     ] + get_default_log_level_args(logger)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        sync_dirs(feedstock_dir, tmpdir, ignore_dot_git=True, update_git=False)
-        chmod_plus_rwX(tmpdir, recursive=True)
+    with tempfile.TemporaryDirectory() as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        sync_dirs(feedstock_dir, str(tmpdir), ignore_dot_git=True, update_git=False)
+        chmod_plus_rwX(str(tmpdir), recursive=True)
 
         logger.debug(
             "host feedstock dir %s: %r",

--- a/conda_forge_feedstock_ops/parse_package_and_feedstock_names.py
+++ b/conda_forge_feedstock_ops/parse_package_and_feedstock_names.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import tempfile
+from pathlib import Path
 
 import conda_build.api
 import conda_build.config
@@ -60,12 +61,13 @@ def _parse_package_and_feedstock_names_containerized(feedstock_dir):
         "parse-package-and-feedstock-names",
     ] + get_default_log_level_args(logger)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
         tmp_feedstock_dir = os.path.join(tmpdir, os.path.basename(feedstock_dir))
         sync_dirs(
             feedstock_dir, tmp_feedstock_dir, ignore_dot_git=True, update_git=False
         )
-        chmod_plus_rwX(tmpdir, recursive=True)
+        chmod_plus_rwX(str(tmpdir), recursive=True)
 
         logger.debug(
             "host feedstock dir %s: %r",

--- a/conda_forge_feedstock_ops/parse_package_and_feedstock_names.py
+++ b/conda_forge_feedstock_ops/parse_package_and_feedstock_names.py
@@ -15,6 +15,7 @@ from rattler_build_conda_compat.render import MetaData as RattlerBuildMetaData
 from yaml import safe_load
 
 from conda_forge_feedstock_ops.container_utils import (
+    Mount,
     get_default_log_level_args,
     run_container_operation,
     should_use_container,
@@ -82,8 +83,7 @@ def _parse_package_and_feedstock_names_containerized(feedstock_dir):
 
         data = run_container_operation(
             args,
-            mount_readonly=True,
-            mount_dir=tmpdir,
+            mounts=[Mount.to_cf_feedstock_ops_dir(tmpdir, read_only=True)],
             json_loads=loads,
         )
 

--- a/conda_forge_feedstock_ops/rerender.py
+++ b/conda_forge_feedstock_ops/rerender.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from threading import Event, Thread
 
 from conda_forge_feedstock_ops.container_utils import (
+    Mount,
     get_default_log_level_args,
     run_container_operation,
     should_use_container,
@@ -110,9 +111,7 @@ def rerender_containerized(feedstock_dir: str, timeout=None):
         )
 
         data = run_container_operation(
-            args,
-            mount_readonly=False,
-            mount_dir=tmpdir,
+            args, mounts=[Mount.to_cf_feedstock_ops_dir(tmpdir, read_only=False)]
         )
 
         if data["commit_message"] is not None and data["patch"] is not None:


### PR DESCRIPTION
# Motivation

This is NOT a result of the discussion in https://github.com/regro/cf-scripts/issues/4186. Instead, I want to pass the settings object of cf-scripts to the container tasks. I want to do this by dumping the settings object to a JSON file, mounting it read-only, and deserializing it again within the container. Currently, this is prevented by `run_container_operation` only accepting one single mount to `/cf_feedstock_ops`.

# Changes

This PR **changes the signature** of `run_container_operation` to accept multiple directories to be mounted instead of enforcing one single mount to `/cf_feedstock_ops`. To make the transition easy, `/cf_feedstock_ops` is exposed as a new pathlib constant `CF_FEEDSTOCK_OPS_DIR`.

Unfortunately, I saw that a lot of existing code still uses `os.path` instead of `pathlib`, so I had to make some changes here and there. Can we please agree on using `pathlib` for new code?

The signature change is a breaking change. Old code looking like this:

```python
run_container_operation(
    args,
    mount_readonly=True,
    mount_dir=tmpdir,
    input="input"
)
```

has to be changed to 

```python
run_container_operation(
    args,
    mounts=[Mount(tmpdir, read_only=True)]
    stdin_input="input"
)
```

I know you are very conservative about breaking changes. However, the old signature uses `str` instead of `pathlib` paths, supports only one mount, and is [only used by cf-scripts](https://github.com/search?q=run_container_operation&type=code). Of course, I will make the necessary adjustments there.